### PR TITLE
CE - Add placeholder image for Items

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -9,6 +9,8 @@ import {
   ITEM_PAGE_UNLOADED,
 } from "../../constants/actionTypes";
 
+const DEFUALT_IMG_URL = "/placeholder.png"
+
 const mapStateToProps = (state) => ({
   ...state.item,
   currentUser: state.common.currentUser,
@@ -44,13 +46,14 @@ class Item extends React.Component {
     const canModify =
       this.props.currentUser &&
       this.props.currentUser.username === this.props.item.seller.username;
+
     return (
       <div className="container page">
         <div className="text-dark">
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || DEFUALT_IMG_URL}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -6,19 +6,19 @@ import { connect } from "react-redux";
 import marked from "marked";
 import {
   ITEM_PAGE_LOADED,
-  ITEM_PAGE_UNLOADED,
+  ITEM_PAGE_UNLOADED
 } from "../../constants/actionTypes";
 
-const DEFUALT_IMG_URL = "/placeholder.png"
+const DEFUALT_IMG_URL = "/placeholder.png";
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   ...state.item,
-  currentUser: state.common.currentUser,
+  currentUser: state.common.currentUser
 });
 
-const mapDispatchToProps = (dispatch) => ({
-  onLoad: (payload) => dispatch({ type: ITEM_PAGE_LOADED, payload }),
-  onUnload: () => dispatch({ type: ITEM_PAGE_UNLOADED }),
+const mapDispatchToProps = dispatch => ({
+  onLoad: payload => dispatch({ type: ITEM_PAGE_LOADED, payload }),
+  onUnload: () => dispatch({ type: ITEM_PAGE_UNLOADED })
 });
 
 class Item extends React.Component {
@@ -26,7 +26,7 @@ class Item extends React.Component {
     this.props.onLoad(
       Promise.all([
         agent.Items.get(this.props.match.params.id),
-        agent.Comments.forItem(this.props.match.params.id),
+        agent.Comments.forItem(this.props.match.params.id)
       ])
     );
   }
@@ -41,7 +41,7 @@ class Item extends React.Component {
     }
 
     const markup = {
-      __html: marked(this.props.item.description, { sanitize: true }),
+      __html: marked(this.props.item.description, { sanitize: true })
     };
     const canModify =
       this.props.currentUser &&
@@ -63,8 +63,8 @@ class Item extends React.Component {
             <div className="col-6">
               <h1>{this.props.item.title}</h1>
               <ItemMeta item={this.props.item} canModify={canModify} />
-              <div dangerouslySetInnerHTML={markup}></div>
-              {this.props.item.tagList.map((tag) => {
+              <div dangerouslySetInnerHTML={markup} />
+              {this.props.item.tagList.map(tag => {
                 return (
                   <span className="badge badge-secondary p-2 mx-1" key={tag}>
                     {tag}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -6,19 +6,19 @@ import { connect } from "react-redux";
 import marked from "marked";
 import {
   ITEM_PAGE_LOADED,
-  ITEM_PAGE_UNLOADED
+  ITEM_PAGE_UNLOADED,
 } from "../../constants/actionTypes";
 
 const DEFUALT_IMG_URL = "/placeholder.png";
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   ...state.item,
-  currentUser: state.common.currentUser
+  currentUser: state.common.currentUser,
 });
 
-const mapDispatchToProps = dispatch => ({
-  onLoad: payload => dispatch({ type: ITEM_PAGE_LOADED, payload }),
-  onUnload: () => dispatch({ type: ITEM_PAGE_UNLOADED })
+const mapDispatchToProps = (dispatch) => ({
+  onLoad: (payload) => dispatch({ type: ITEM_PAGE_LOADED, payload }),
+  onUnload: () => dispatch({ type: ITEM_PAGE_UNLOADED }),
 });
 
 class Item extends React.Component {
@@ -26,7 +26,7 @@ class Item extends React.Component {
     this.props.onLoad(
       Promise.all([
         agent.Items.get(this.props.match.params.id),
-        agent.Comments.forItem(this.props.match.params.id)
+        agent.Comments.forItem(this.props.match.params.id),
       ])
     );
   }
@@ -41,7 +41,7 @@ class Item extends React.Component {
     }
 
     const markup = {
-      __html: marked(this.props.item.description, { sanitize: true })
+      __html: marked(this.props.item.description, { sanitize: true }),
     };
     const canModify =
       this.props.currentUser &&
@@ -64,7 +64,7 @@ class Item extends React.Component {
               <h1>{this.props.item.title}</h1>
               <ItemMeta item={this.props.item} canModify={canModify} />
               <div dangerouslySetInnerHTML={markup} />
-              {this.props.item.tagList.map(tag => {
+              {this.props.item.tagList.map((tag) => {
                 return (
                   <span className="badge badge-secondary p-2 mx-1" key={tag}>
                     {tag}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -29,6 +29,8 @@ const ItemPreview = (props) => {
     }
   };
 
+  const DEFUALT_IMG_URL = "/placeholder.png"
+
   return (
     <div
       className="card bg-dark border-light p-3"
@@ -36,7 +38,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || DEFUALT_IMG_URL}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -4,23 +4,23 @@ import agent from "../agent";
 import { connect } from "react-redux";
 import { ITEM_FAVORITED, ITEM_UNFAVORITED } from "../constants/actionTypes";
 
-const mapDispatchToProps = (dispatch) => ({
-  favorite: (slug) =>
+const mapDispatchToProps = dispatch => ({
+  favorite: slug =>
     dispatch({
       type: ITEM_FAVORITED,
-      payload: agent.Items.favorite(slug),
+      payload: agent.Items.favorite(slug)
     }),
-  unfavorite: (slug) =>
+  unfavorite: slug =>
     dispatch({
       type: ITEM_UNFAVORITED,
-      payload: agent.Items.unfavorite(slug),
-    }),
+      payload: agent.Items.unfavorite(slug)
+    })
 });
 
-const ItemPreview = (props) => {
+const ItemPreview = props => {
   const item = props.item;
 
-  const handleClick = (ev) => {
+  const handleClick = ev => {
     ev.preventDefault();
     if (item.favorited) {
       props.unfavorite(item.slug);
@@ -29,7 +29,7 @@ const ItemPreview = (props) => {
     }
   };
 
-  const DEFUALT_IMG_URL = "/placeholder.png"
+  const DEFUALT_IMG_URL = "/placeholder.png";
 
   return (
     <div
@@ -56,7 +56,7 @@ const ItemPreview = (props) => {
             />
           </Link>
           <button className="btn btn-outline-secondary" onClick={handleClick}>
-            <i className="ion-heart"></i> {item.favoritesCount}
+            <i className="ion-heart" /> {item.favoritesCount}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -4,23 +4,23 @@ import agent from "../agent";
 import { connect } from "react-redux";
 import { ITEM_FAVORITED, ITEM_UNFAVORITED } from "../constants/actionTypes";
 
-const mapDispatchToProps = dispatch => ({
-  favorite: slug =>
+const mapDispatchToProps = (dispatch) => ({
+  favorite: (slug) =>
     dispatch({
       type: ITEM_FAVORITED,
-      payload: agent.Items.favorite(slug)
+      payload: agent.Items.favorite(slug),
     }),
-  unfavorite: slug =>
+  unfavorite: (slug) =>
     dispatch({
       type: ITEM_UNFAVORITED,
-      payload: agent.Items.unfavorite(slug)
-    })
+      payload: agent.Items.unfavorite(slug),
+    }),
 });
 
-const ItemPreview = props => {
+const ItemPreview = (props) => {
   const item = props.item;
 
-  const handleClick = ev => {
+  const handleClick = (ev) => {
     ev.preventDefault();
     if (item.favorited) {
       props.unfavorite(item.slug);

--- a/frontend/src/reducers/auth.js
+++ b/frontend/src/reducers/auth.js
@@ -4,7 +4,7 @@ import {
   LOGIN_PAGE_UNLOADED,
   REGISTER_PAGE_UNLOADED,
   ASYNC_START,
-  UPDATE_FIELD_AUTH
+  UPDATE_FIELD_AUTH,
 } from "../constants/actionTypes";
 
 const reducer = (state = {}, action) => {
@@ -14,7 +14,7 @@ const reducer = (state = {}, action) => {
       return {
         ...state,
         inProgress: false,
-        errors: action.error ? action.payload.errors : null
+        errors: action.error ? action.payload.errors : null,
       };
     case LOGIN_PAGE_UNLOADED:
     case REGISTER_PAGE_UNLOADED:

--- a/frontend/src/reducers/auth.js
+++ b/frontend/src/reducers/auth.js
@@ -4,7 +4,7 @@ import {
   LOGIN_PAGE_UNLOADED,
   REGISTER_PAGE_UNLOADED,
   ASYNC_START,
-  UPDATE_FIELD_AUTH,
+  UPDATE_FIELD_AUTH
 } from "../constants/actionTypes";
 
 const reducer = (state = {}, action) => {
@@ -14,7 +14,7 @@ const reducer = (state = {}, action) => {
       return {
         ...state,
         inProgress: false,
-        errors: action.error ? action.payload.errors : null,
+        errors: action.error ? action.payload.errors : null
       };
     case LOGIN_PAGE_UNLOADED:
     case REGISTER_PAGE_UNLOADED:


### PR DESCRIPTION
# Add Default image for Item Component

Adds a default path to `placeholder.png` if a user does not specify an image url when creating an item.
Closes #2 

Fixes Item List View
![image](https://user-images.githubusercontent.com/289105/195253332-0258593a-510b-470d-80c7-8f6ff9a91dee.png)

And Item Detail View
![image](https://user-images.githubusercontent.com/289105/195253363-ee82fc0a-87a4-4c07-a662-6b67f8bdfffb.png)
